### PR TITLE
Add Batch Address Generation Endpoint with Templated Derivation Path

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -120,6 +120,44 @@ Returns randomly generated user UUID
 				},
 			},
 
+			// api/address/batch
+			{
+				Pattern:      "address/batch",
+				HelpSynopsis: "Generate a batch of addresses for a user",
+				HelpDescription: `
+
+Generates a batch of addresses from stored mnemonic and passphrase using a templated derivation path.
+(e.g., m/44'/60'/0'/0/%d).
+
+`,
+				Fields: map[string]*framework.FieldSchema{
+					"uuid": {
+						Type:        framework.TypeString,
+						Description: "UUID of user",
+					},
+					"pathTemplate": {
+						Type:        framework.TypeString,
+						Description: "Templated derivation path, e.g., m/44'/60'/0'/0/%d",
+					},
+					"coinType": {
+						Type:        framework.TypeInt,
+						Description: "Cointype of transaction",
+					},
+					"startIndex": {
+						Type:        framework.TypeInt,
+						Description: "Start index for address generation",
+						Default:     0,
+					},
+					"count": {
+						Type:        framework.TypeInt,
+						Description: "Number of addresses to generate",
+					},
+				},
+				Callbacks: map[logical.Operation]framework.OperationFunc{
+					logical.UpdateOperation: b.pathAddressBatch,
+				},
+			},
+
 			// api/info
 			{
 				Pattern:      "info",

--- a/api/path_address_batch_test.go
+++ b/api/path_address_batch_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/payment-system/dq-vault/api/helpers"
+	"github.com/payment-system/dq-vault/config"
+)
+
+// MockStorageBatch implements logical.Storage for testing
+// (pattern from path_address_test.go)
+type MockStorageBatch struct {
+	mock.Mock
+}
+
+func (m *MockStorageBatch) List(ctx context.Context, prefix string) ([]string, error) {
+	args := m.Called(ctx, prefix)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorageBatch) Get(ctx context.Context, key string) (*logical.StorageEntry, error) {
+	args := m.Called(ctx, key)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*logical.StorageEntry), args.Error(1)
+}
+
+func (m *MockStorageBatch) Put(ctx context.Context, entry *logical.StorageEntry) error {
+	args := m.Called(ctx, entry)
+	return args.Error(0)
+}
+
+func (m *MockStorageBatch) Delete(ctx context.Context, key string) error {
+	args := m.Called(ctx, key)
+	return args.Error(0)
+}
+
+func createBatchFieldData(data map[string]interface{}) *framework.FieldData {
+	schema := map[string]*framework.FieldSchema{
+		"uuid": {
+			Type:        framework.TypeString,
+			Description: "UUID of user",
+		},
+		"pathTemplate": {
+			Type:        framework.TypeString,
+			Description: "Templated derivation path",
+		},
+		"coinType": {
+			Type:        framework.TypeInt,
+			Description: "Coin type",
+		},
+		"isDev": {
+			Type:        framework.TypeBool,
+			Description: "Development mode flag",
+		},
+		"startIndex": {
+			Type:        framework.TypeInt,
+			Description: "Start index",
+		},
+		"count": {
+			Type:        framework.TypeInt,
+			Description: "Count",
+		},
+	}
+	return &framework.FieldData{
+		Raw:    data,
+		Schema: schema,
+	}
+}
+
+func createBatchTestBackend(_ *testing.T) *Backend {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	return &Backend{
+		logger: logger,
+	}
+}
+
+func createUserStorageEntryBatch(t *testing.T, uuid, mnemonic, passphrase string) *logical.StorageEntry {
+	user := helpers.User{
+		UUID:       uuid,
+		Mnemonic:   mnemonic,
+		Passphrase: passphrase,
+	}
+	data, err := json.Marshal(user)
+	require.NoError(t, err)
+	return &logical.StorageEntry{
+		Key:   config.StorageBasePath + uuid,
+		Value: data,
+	}
+}
+
+func TestBackend_PathAddressBatch(t *testing.T) {
+	ctx := context.Background()
+	const (
+		testUUID     = "test-uuid-batch"
+		testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		testPass     = "test-passphrase"
+	)
+
+	mockStorage := new(MockStorageBatch)
+	entry := createUserStorageEntryBatch(t, testUUID, testMnemonic, testPass)
+	mockStorage.On("Get", ctx, config.StorageBasePath+testUUID).Return(entry, nil)
+	mockStorage.On("List", ctx, config.StorageBasePath).Return([]string{testUUID}, nil)
+
+	backend := createBatchTestBackend(t)
+	fieldData := createBatchFieldData(map[string]interface{}{
+		"uuid":         testUUID,
+		"pathTemplate": "m/44'/60'/0'/0/%d",
+		"coinType":     60, // Ether
+		"isDev":        false,
+		"startIndex":   0,
+		"count":        3,
+	})
+
+	req := &logical.Request{
+		Storage: mockStorage,
+		Data: map[string]interface{}{
+			"uuid":         testUUID,
+			"pathTemplate": "m/44'/60'/0'/0/%d",
+			"coinType":     60,
+			"isDev":        false,
+			"startIndex":   0,
+			"count":        3,
+		},
+	}
+
+	resp, err := backend.pathAddressBatch(ctx, req, fieldData)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Contains(t, resp.Data, "addresses")
+	addresses, ok := resp.Data["addresses"].(map[string]string)
+	assert.True(t, ok)
+	assert.Len(t, addresses, 3)
+	for _, addr := range addresses {
+		assert.NotEmpty(t, addr)
+	}
+}

--- a/setup/vault_postman_collection.json
+++ b/setup/vault_postman_collection.json
@@ -538,6 +538,64 @@
 						"description": "Generate a Bitshares (BTS) address using BIP-44 derivation path"
 					},
 					"response": []
+				},
+				{
+					"name": "Batch Generate Addresses",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response contains addresses object\", function () {",
+									"    const responseJson = pm.response.json();",
+									"    pm.expect(responseJson.data).to.have.property('addresses');",
+									"    pm.expect(responseJson.data.addresses).to.be.an('object');",
+									"    Object.values(responseJson.data.addresses).forEach(function(addr) {",
+									"        pm.expect(addr).to.be.a('string');",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-Vault-Token",
+								"value": "{{vault_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"uuid\": \"{{user_uuid}}\",\n    \"coinType\": 0,\n    \"paths\": [\"m/44'/0'/0'/0/0\", \"m/44'/0'/0'/0/1\"]\n}"
+						},
+						"url": {
+							"raw": "{{vault_url}}/v1/dq/address/batch",
+							"host": [
+								"{{vault_url}}"
+							],
+							"path": [
+								"v1",
+								"dq",
+								"address",
+								"batch"
+							]
+						},
+						"description": "Batch generate addresses for a user by providing an array of derivation paths."
+					},
+					"response": []
 				}
 			],
 			"description": "Address generation endpoints for various cryptocurrencies"


### PR DESCRIPTION
## Feature: Batch Address Generation Endpoint

### Overview

This PR introduces a new API endpoint that allows clients to generate multiple blockchain addresses in a single request using a templated derivation path. This is useful for applications that need to pre-generate a set of addresses for a user (e.g., wallets, exchanges, or batch payment systems).

---

### Key Changes

- **New Endpoint:**  
  `POST /address/batch`  
  Accepts parameters for UUID, templated derivation path, coin type, start index, and count.  
  Returns a list of derived addresses.

- **Handler Implementation:**  
  - Added `pathAddressBatch` in `api/path_address_batch.go`.
  - Uses a templated derivation path (e.g., `m/44'/60'/0'/0/%d`) and replaces `%d` with the index for each address in the batch.
  - Validates input and enforces a reasonable limit on batch size.

- **Backend Registration:**  
  - Registered the new endpoint in `api/backend.go` with appropriate field schema and help text.

- **Testing:**  
  - Added `api/path_address_batch_test.go` with a test for successful batch address generation.

---

### Example Usage

**Request:**
```json
{
  "uuid": "user-uuid",
  "path_template": "m/44'/60'/0'/0/%d",
  "coinType": 60,
  "start_index": 0,
  "count": 3
}
```

**Response:**
```json
{
  "addresses": {
      "m/44'/0'/0'/0/0": "address1",
      "m/44'/0'/0'/0/1": "address2",
      "m/44'/0'/0'/0/2": "address3"
    }
}
```

---

### Notes

- The endpoint supports up to 1000 addresses per request (configurable in code).
- The derivation path must include a `%d` placeholder for the index.
- The `isDev` flag is still supported in the handler for compatibility, but is not exposed in the endpoint schema by default.

---

**Type:** Feature  
**Impact:** API, backend, tests
